### PR TITLE
Isolate test index persistence with per-run temp directory

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,18 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll } from 'vitest';
+
+let tempDir: string | undefined;
+
+beforeAll(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'jp-labor-evidence-test-'));
+  process.env.LABOR_LAW_MCP_INDEX_DIR = tempDir;
+});
+
+afterAll(() => {
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./tests/setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- 0.3.0 の `npm publish` (= `prepublishOnly` で `release:check` 実行) が、`tests/mhlw-service.test.ts` の 3 件で `IndexPromotionError: ENTRY_COUNT_DROP_TOO_LARGE` を踏んで失敗
- 原因: テストが `.jp-labor-evidence-indexes/` に persist し、次回実行で `current.entry_count >= 10` の状態に対し mock の 2 件が drop 比率閾値に引っ掛かる
- 修正: 新規 `vitest.config.ts` + `tests/setup.ts` で `LABOR_LAW_MCP_INDEX_DIR` を per-file temp dir に切り替え、production-style state からテストを完全分離

## Test Plan

- [x] 汚染状態の `.jp-labor-evidence-indexes/` を残したまま `npm test` → 30 files / 106 tests pass
- [x] `npm run release:check` pass、0.3.0 tarball 生成
- [x] env var `LABOR_LAW_MCP_INDEX_DIR` の override は既存実装 (`src/lib/indexes/index-store.ts:6-10`) を活用、production behavior には影響なし

## Notes

- 0.3.0 publish の release blocker。merge 後に user 側で `npm publish` 再実行可能
- バージョン bump は不要（0.3.0 はまだ publish されていないため）
- 関連: PR #8 (freshness warnings 0.3.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)