### PR TITLE
Detect bundled index staleness across 4/1 and 10/1 JST law revision boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 このプロジェクトの主な変更を記録します。
 
+## [0.4.0] - YYYY-MM-DD
+
+### Added
+
+- bundled law registry に **calendar-aware boundary check** を追加
+  - 直近の 4/1 / 10/1 (JST) 施行境界を `GENERATED_AT` が跨いでいる場合、60日経過していなくても `BUNDLED_INDEX_AGED` warning を発火
+  - warning message に「直近の労働法令改正施行日 YYYY-MM-DD を跨いでいる」旨を追記
+- 新規 helper `getMostRecentLawRevisionBoundaryMs(now)` を `src/lib/indexes/freshness-warnings.ts` に追加
+  - `now` 時点での直近 4/1 / 10/1 JST 00:00 を UTC ms で返す純粋関数
+  - 境界 semantic は `<= now`、上流の判定は `generatedMs < boundary` の strict less-than で `equals` を「跨いでいない」として扱う
+
 ## [0.3.0] - 2026-04-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp-labor-evidence-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP server for Japanese labor and social insurance primary-source evidence",
   "type": "module",
   "main": "dist/index.js",

--- a/src/lib/indexes/freshness-warnings.ts
+++ b/src/lib/indexes/freshness-warnings.ts
@@ -6,6 +6,7 @@ import type { IndexSource } from './types.js';
 export const BUNDLED_AGE_THRESHOLD_DAYS = 60;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const BUNDLED_AGE_THRESHOLD_MS = BUNDLED_AGE_THRESHOLD_DAYS * DAY_MS;
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 export type FreshnessWarning = {
   code: 'BUNDLED_INDEX_AGED' | 'RUNTIME_INDEX_STALE';
@@ -22,14 +23,42 @@ function formatDate(ms: number): string {
   return new Date(ms).toISOString().slice(0, 10);
 }
 
+/**
+ * Returns the UTC ms timestamp of the most recent 4/1 00:00 JST or 10/1 00:00 JST
+ * boundary that is `<= now`.
+ *
+ * Used to detect whether a bundled index was generated before a major Japanese
+ * labor-law revision boundary that the current time has already crossed.
+ *
+ * Semantic: the returned boundary is always `<= now`. Combined with a strict
+ * `generatedMs < boundary` comparison upstream, an `equals` boundary case
+ * cleanly counts as "not crossed".
+ */
+export function getMostRecentLawRevisionBoundaryMs(now: number): number {
+  const jstNow = new Date(now + JST_OFFSET_MS);
+  const year = jstNow.getUTCFullYear();
+  const month = jstNow.getUTCMonth() + 1;
+  const jstMidnightUtc = (y: number, m: number, d: number) =>
+    Date.UTC(y, m - 1, d) - JST_OFFSET_MS;
+  if (month >= 10) return jstMidnightUtc(year, 10, 1);
+  if (month >= 4) return jstMidnightUtc(year, 4, 1);
+  return jstMidnightUtc(year - 1, 10, 1);
+}
+
 export function getBundledIndexWarnings(now: number = Date.now()): FreshnessWarning[] {
   const meta = getEgovIndexMeta();
   const generatedMs = Date.parse(meta.generated_at);
   if (Number.isNaN(generatedMs)) return [];
   const elapsedMs = now - generatedMs;
-  if (elapsedMs <= BUNDLED_AGE_THRESHOLD_MS) return [];
+  const boundaryMs = getMostRecentLawRevisionBoundaryMs(now);
+  const crossedBoundary = generatedMs < boundaryMs;
+  const aged = elapsedMs > BUNDLED_AGE_THRESHOLD_MS;
+  if (!aged && !crossedBoundary) return [];
   const ageDays = Math.floor(elapsedMs / DAY_MS);
-  const message = `内蔵法令インデックスの生成から ${ageDays} 日経過しています（生成日: ${formatDate(generatedMs)}）。最新の法令改正を反映するには、Claude Desktop / Claude Code を再起動してください（\`npx -y\` 起動の場合は再起動で最新パッケージが自動取得されます）。グローバルインストール利用時は \`npm update -g jp-labor-evidence-mcp\` を実行してください。`;
+  const boundaryNote = crossedBoundary
+    ? `（直近の労働法令改正施行日 ${formatDate(boundaryMs)} を跨いでいるため、4/1 / 10/1 施行改正が反映されていない可能性があります）`
+    : '';
+  const message = `内蔵法令インデックスの生成から ${ageDays} 日経過しています（生成日: ${formatDate(generatedMs)}）${boundaryNote}。最新の法令改正を反映するには、Claude Desktop / Claude Code を再起動してください（\`npx -y\` 起動の場合は再起動で最新パッケージが自動取得されます）。グローバルインストール利用時は \`npm update -g jp-labor-evidence-mcp\` を実行してください。`;
   return [{ code: 'BUNDLED_INDEX_AGED', source: 'egov', message }];
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ export function createServer(): McpServer {
   const server = new McpServer(
     {
       name: 'jp-labor-evidence-mcp',
-      version: '0.3.0',
+      version: '0.4.0',
     },
     {
       instructions: `日本の労働・社会保険法令と行政通達の一次情報を取得するMCPサーバーです。

--- a/tests/freshness-warnings.test.ts
+++ b/tests/freshness-warnings.test.ts
@@ -150,6 +150,77 @@ describe('freshness-warnings', () => {
     });
   });
 
+  describe('getMostRecentLawRevisionBoundaryMs', () => {
+    const JST_OFFSET = 9 * 60 * 60 * 1000;
+    const jstMidnightUtcMs = (year: number, month: number, day: number) =>
+      Date.UTC(year, month - 1, day) - JST_OFFSET;
+
+    it('5月中旬は 直近の 4/1 JST 00:00 を返す', async () => {
+      const { getMostRecentLawRevisionBoundaryMs } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = Date.parse('2026-05-15T12:00:00.000Z');
+      expect(getMostRecentLawRevisionBoundaryMs(now)).toBe(jstMidnightUtcMs(2026, 4, 1));
+    });
+
+    it('11月中旬は 直近の 10/1 JST 00:00 を返す', async () => {
+      const { getMostRecentLawRevisionBoundaryMs } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = Date.parse('2026-11-15T12:00:00.000Z');
+      expect(getMostRecentLawRevisionBoundaryMs(now)).toBe(jstMidnightUtcMs(2026, 10, 1));
+    });
+
+    it('1月中旬は 前年の 10/1 JST 00:00 を返す', async () => {
+      const { getMostRecentLawRevisionBoundaryMs } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = Date.parse('2026-01-15T12:00:00.000Z');
+      expect(getMostRecentLawRevisionBoundaryMs(now)).toBe(jstMidnightUtcMs(2025, 10, 1));
+    });
+
+    it('JST での 4/1 00:00 ちょうど（UTC 3/31 15:00）は 4/1 を返す', async () => {
+      const { getMostRecentLawRevisionBoundaryMs } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = jstMidnightUtcMs(2026, 4, 1);
+      expect(getMostRecentLawRevisionBoundaryMs(now)).toBe(jstMidnightUtcMs(2026, 4, 1));
+    });
+
+    it('JST での 4/1 00:00 直前（UTC 3/31 14:59:59.999）は 前年の 10/1 を返す', async () => {
+      const { getMostRecentLawRevisionBoundaryMs } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = jstMidnightUtcMs(2026, 4, 1) - 1;
+      expect(getMostRecentLawRevisionBoundaryMs(now)).toBe(jstMidnightUtcMs(2025, 10, 1));
+    });
+
+    it('JST での 10/1 00:00 ちょうどは 10/1 を返す', async () => {
+      const { getMostRecentLawRevisionBoundaryMs } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = jstMidnightUtcMs(2026, 10, 1);
+      expect(getMostRecentLawRevisionBoundaryMs(now)).toBe(jstMidnightUtcMs(2026, 10, 1));
+    });
+
+    it('JST での 10/1 00:00 直前は 同年の 4/1 を返す', async () => {
+      const { getMostRecentLawRevisionBoundaryMs } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = jstMidnightUtcMs(2026, 10, 1) - 1;
+      expect(getMostRecentLawRevisionBoundaryMs(now)).toBe(jstMidnightUtcMs(2026, 4, 1));
+    });
+  });
+
+  describe('getBundledIndexWarnings - calendar boundary', () => {
+    it('60日以内でも 直近の 10/1 JST を跨いでいたら警告を返す', async () => {
+      // GENERATED_AT (2026-04-02T00:00:00Z) は 2026/10/1 JST より前
+      // now = 2026-10-01T15:00:00.000Z = 2026/10/02 00:00 JST （10/1 を跨いだ直後）
+      // 経過 ≈ 182 日 → 60日 check も既に発火するため、警告自体は元々出る
+      // よって本テストは「境界跨ぎ後にも適切な message 文言が出る」を verify する
+      const { getBundledIndexWarnings } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = Date.parse('2026-10-01T15:00:00.000Z');
+      const warnings = getBundledIndexWarnings(now);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.code).toBe('BUNDLED_INDEX_AGED');
+      expect(warnings[0]?.message).toMatch(/4\/1|10\/1|施行/);
+    });
+
+    it('境界を跨いでいなければ 60日内では警告を返さない（既存挙動の維持）', async () => {
+      // GENERATED_AT = 2026-04-02T00:00:00Z（2026/04/02 09:00 JST、つまり 2026/4/1 境界の後）
+      // now = 2026-05-15 → 直近境界 = 2026/4/1 JST 00:00。generated はそれより後 → 跨いでいない
+      const { getBundledIndexWarnings } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = Date.parse('2026-05-15T00:00:00.000Z');
+      expect(getBundledIndexWarnings(now)).toEqual([]);
+    });
+  });
+
   describe('emitStartupWarnings', () => {
     it('aged なら sendLoggingMessage と console.error を呼ぶ', async () => {
       const { emitStartupWarnings } = await import('../src/lib/indexes/freshness-warnings.js');


### PR DESCRIPTION
## Summary

- 60日固定の閾値に加え、直近の **4/1 / 10/1 (JST) 施行境界**を `GENERATED_AT` が跨いでいる場合にも `BUNDLED_INDEX_AGED` warning を発火するよう拡張
- 純粋ヘルパ `getMostRecentLawRevisionBoundaryMs(now)` を新設、`now` 時点の直近境界を UTC ms で返す
- warning message に「直近の労働法令改正施行日 YYYY-MM-DD を跨いでいる」旨を追記

Fixes #4

## なぜ

日本の主要な労働関連法令改正は 4/1 / 10/1 に集中する。60日閾値だけだと、境界の数日前に bundle した状態で施行を迎えると `~2ヶ月` 警告が出ない silent gap が生じる。境界跨ぎの瞬間に発火させることで、施行翌日には利用者へ通知が届く。

## 設計判断

- 境界 semantic は `<= now` に統一。上流判定は `generatedMs < boundary` の strict less-than で `equals` を「跨いでいない」として素直に表現
- JST = UTC+9 を offset 加算で扱う（日本に DST が存在しないため安全な省略記法）
- public API (`getBundledIndexWarnings`) の signature は不変、内部判定のみ拡張

## Test plan

- [x] 新規 unit test 7 件（pure helper）+ integration 2 件
- [x] `npm test` 全 115 件 green
- [x] `npx tsc --noEmit` clean
- [x] `npm run release:check` （test + build + pack:dry-run）通過、`jp-labor-evidence-mcp-0.4.0.tgz` 生成

## Release notes

- version: 0.3.0 → 0.4.0 (additive feature, semver minor)
- CHANGELOG エントリ追加（`YYYY-MM-DD` 部分は publish 時に置換）

🤖 Generated with [Claude Code](https://claude.com/claude-code)