### PR TITLE
test: pin egov freshness clock with fake timers (Closes #14)

### DIFF
--- a/tests/find-related-sources-tool.test.ts
+++ b/tests/find-related-sources-tool.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 vi.mock('../src/lib/services/law-service.js', () => ({
@@ -7,6 +7,7 @@ vi.mock('../src/lib/services/law-service.js', () => ({
 
 import { findRelatedSources } from '../src/lib/services/law-service.js';
 import { registerFindRelatedSourcesTool } from '../src/tools/find-related-sources.js';
+import { getEgovIndexMeta } from '../src/lib/indexes/egov-index.js';
 
 function createServerStub(registerTool: ReturnType<typeof vi.fn>): McpServer {
   return { registerTool } as unknown as McpServer;
@@ -14,7 +15,16 @@ function createServerStub(registerTool: ReturnType<typeof vi.fn>): McpServer {
 
 describe('find_related_sources tool', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    // Pin the clock to the bundled index's own generation time so egov freshness
+    // is always evaluated as "fresh"; keeps BUNDLED_INDEX_AGED out of tool
+    // warnings[0] regardless of wall-clock or future GENERATED_AT bumps (Issue #14).
+    vi.setSystemTime(new Date(getEgovIndexMeta().generated_at));
     vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('structuredContent で委任先候補を返す', async () => {

--- a/tests/tool-wire-contract.test.ts
+++ b/tests/tool-wire-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 vi.mock('../src/lib/services/law-service.js', () => ({
@@ -14,6 +14,7 @@ import { registerGetLawTool } from '../src/tools/get-law.js';
 import { registerSearchLawTool } from '../src/tools/search-law.js';
 import { registerResolveLawTool } from '../src/tools/resolve-law.js';
 import { registerGetArticleTool } from '../src/tools/get-article.js';
+import { getEgovIndexMeta } from '../src/lib/indexes/egov-index.js';
 
 type RegisterToolMock = ReturnType<typeof vi.fn>;
 
@@ -23,7 +24,16 @@ function createServerStub(registerTool: RegisterToolMock): McpServer {
 
 describe('tool wire contract', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    // Pin the clock to the bundled index's own generation time so egov freshness
+    // is always evaluated as "fresh"; keeps BUNDLED_INDEX_AGED out of tool
+    // warnings[0] regardless of wall-clock or future GENERATED_AT bumps (Issue #14).
+    vi.setSystemTime(new Date(getEgovIndexMeta().generated_at));
     vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('search_law は outputSchema と structuredContent を返す', async () => {


### PR DESCRIPTION
## 概要

Issue #14 の time-bomb を解消。`tool-wire-contract` / `find-related-sources` の tool テストが egov bundled freshness を **実時刻 (`Date.now()`)** で評価していたため、`GENERATED_AT` から 60 日経過すると `BUNDLED_INDEX_AGED` が `warnings[0]` に割り込み、`warnings[0]?.code` を tool 固有値と期待する assertion が赤化していた。

## 変更

両ファイルの `beforeEach` に fake-timer を導入:

```ts
beforeEach(() => {
  vi.useFakeTimers();
  // 固定時刻を bundled index の生成時刻に合わせ、egov freshness を常に "fresh" に
  vi.setSystemTime(new Date(getEgovIndexMeta().generated_at));
  vi.resetAllMocks();
});
afterEach(() => {
  vi.useRealTimers();
});
```

### 設計の要点

- 固定時刻を **production の `getBundledIndexWarnings` が比較する基準と同一ソース**（`getEgovIndexMeta().generated_at`）から導出。`elapsed = 0` ・境界非跨ぎで必ず fresh と評価される。
- ハードコード日付ではないため、**将来 `GENERATED_AT` を bump しても自動追従**し、テスト側の手動同期が不要（CLAUDE.md gotcha の負債を増やさない）。

## 検証

- `npm test` → **115 passed / 30 files**
- `npm run build`（tsc）→ exit 0（新規 import `getEgovIndexMeta` も型整合）
- **機構の実証**: スクラッチテストで、擬似時刻を `generated_at + 61日`（aged）にすると `warnings[0]` が `BUNDLED_INDEX_AGED` に、`generated_at`（fresh）固定なら `NO_DELEGATED_LAWS_CONFIGURED` になることを確認。freshness が実時刻ではなく固定クロックで決まることを観測（スクラッチは検証後に削除）。

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)