### PR TITLE
chore(deps): override transitive deps to clear 7 audit advisories (Closes #13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jp-labor-evidence-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jp-labor-evidence-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -499,9 +499,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1484,12 +1484,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1508,9 +1508,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1729,9 +1729,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2223,9 +2223,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2311,9 +2311,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -54,5 +54,14 @@
     "tsx": "^4.21.0",
     "typescript": "^5.7.0",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "hono": "^4.12.25",
+    "path-to-regexp": "^8.4.2",
+    "qs": "^6.15.2",
+    "ip-address": "^10.2.0",
+    "fast-uri": "^3.1.2",
+    "@hono/node-server": "^1.19.13",
+    "express-rate-limit": "^8.2.2"
   }
 }


### PR DESCRIPTION
## 概要

Issue #13。`@modelcontextprotocol/sdk@1.29.0` の HTTP transport 系 transitive dependency に由来する `npm audit` の 7 件（high 5 / moderate 2）を、`package.json` の `overrides` で patched 版に pin して解消する。

## なぜ overrides か

- **SDK 1.29.0 が最新で、それ自体が脆弱な transitive を引いている**ため、SDK を更新しても直らない（upstream に修正版がまだ無い）。
- 本サーバーは **stdio transport 専用**で、`express` / `hono` の HTTP/SSE 経路は実行時に呼ばれない（実害は休眠）。それでも audit ノイズは消すべきなので overrides で対処。
- 全 override は **同一 major 内の patched 版**であり、親パッケージの範囲制約と両立する（`fast-uri` は ajv の `^3.0.1` を満たす `^3.1.2` に留め、major 4.x は避けた）。

## overrides 一覧

| パッケージ | 脆弱 | → patched (pin) | advisory |
|---|---|---|---|
| `hono` | <=4.12.20 | `^4.12.25` | IP制限bypass / Cookie注入 / JWT scheme / mount prefix |
| `path-to-regexp` | 8.0.0–8.3.0 | `^8.4.2` | ReDoS ×2 |
| `qs` | 6.11.1–6.15.1 | `^6.15.2` | DoS |
| `ip-address` | <=10.1.0 | `^10.2.0` | Address6 XSS |
| `fast-uri` | <=3.1.1 | `^3.1.2` | path traversal / host confusion |
| `@hono/node-server` | <1.19.13 | `^1.19.13` | (本体 advisory) |
| `express-rate-limit` | 8.2.0–8.2.1 | `^8.2.2` | IPv4-mapped IPv6 で rate limit 回避 |

## 検証

- `npm audit`: **7 → 0 vulnerabilities**
- `npm ci`（lockfile から clean install）後も物理 node_modules・論理ツリー一致、全 7 本 patched を確認
- `npm run release:check`（test + build + pack）: **115 passed / 30 files**、build exit 0

## 注意（後任への申し送り）

`overrides` は **SDK が将来これらの dep を patched 版へ bump したら撤去すべき暫定措置**。SDK 更新時に overrides の要否を再評価すること。

## リリース

本 PR は version bump を含まない（remediation に焦点）。出荷時は `0.4.2` への bump + CHANGELOG + publish が別途必要。

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)