### PR TITLE
ci: add GitHub Actions CI gate and trusted-publishing release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build
+
+      - name: Verify npm package contents
+        run: npm pack --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: Release
+
+# Trusted Publishing (OIDC) を使うため npm token は不要。初回利用前に
+# npmjs.com の本パッケージ設定で Trusted Publisher を 1 度だけ登録すること:
+#   repository = finelagusaz/jp-labor-evidence-mcp / workflow = release.yml
+# package.json の version が main に乗ると発火し、未公開バージョンのみ publish する。
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Read package metadata
+        id: meta
+        run: |
+          {
+            echo "name=$(npm pkg get name | tr -d '"')"
+            echo "version=$(npm pkg get version | tr -d '"')"
+            echo "tag=v$(npm pkg get version | tr -d '"')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check whether version is already published
+        id: npm_state
+        env:
+          PACKAGE_NAME: ${{ steps.meta.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::${PACKAGE_NAME}@${PACKAGE_VERSION} is already published; skipping release."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.npm_state.outputs.published == 'false'
+        run: npm ci
+
+      - name: Run release checks
+        if: steps.npm_state.outputs.published == 'false'
+        run: npm run release:check
+
+      - name: Upgrade npm for trusted publishing
+        if: steps.npm_state.outputs.published == 'false'
+        run: npm install -g "npm@>=11.5.1"
+
+      - name: Publish to npm (provenance)
+        if: steps.npm_state.outputs.published == 'false'
+        run: npm publish --provenance --access public
+
+      - name: Create git tag
+        if: steps.npm_state.outputs.published == 'false'
+        env:
+          TAG_NAME: ${{ steps.meta.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Tag $TAG_NAME already exists"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
+      - name: Create GitHub release
+        if: steps.npm_state.outputs.published == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.meta.outputs.tag }}
+        run: |
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Release $TAG_NAME already exists"
+            exit 0
+          fi
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --generate-notes


### PR DESCRIPTION
## 概要

これまで CI が一切存在しなかった（品質ゲートはローカルの `release:check` / `prepublishOnly` 任せ）ため、`ukagaka-doc-mcp` の構成を範に GitHub Actions を導入する。`0.4.2` リリースに先立つ整備。

## 追加する workflow

### `ci.yml` — 品質ゲート
- トリガー: `pull_request` / `push`(main)/ `workflow_dispatch`
- **Node 20 / 22 / 24 マトリクス**で `npm ci → test → build → npm pack --dry-run`
- `npx -y` 経由で多様な Node 版に届く CLI のため、参考実装（単一 Node 20）より互換検証を厚めに

### `release.yml` — Trusted Publishing による自動リリース
- トリガー: `push`(main, `paths: package.json`)/ `workflow_dispatch`
- `npm view` で**既に公開済みの version なら skip**（idempotent、二重出荷防止）
- 未公開なら `npm ci → release:check → npm publish --provenance` で **OIDC Trusted Publishing**、続けて `git tag vX.Y.Z` と GitHub release を自動生成
- **npm token 不要・publish 時の 2FA を回避**（CI から人手なしで出荷可能に）

`refresh-index-pr.yml` 相当は**適応していない**: 本リポジトリの bundled index はネットワーク同期を持たず、再キュレーションは手作業のドメイン仕事のため。

## ⚠️ マージ前/後に必要な 1 回限りの設定

`release.yml` が機能するには、**npmjs.com で本パッケージの Trusted Publisher を登録**する必要があります（未設定だと初回 OIDC publish が失敗）:

1. https://www.npmjs.com/package/jp-labor-evidence-mcp → **Settings → Trusted Publisher**
2. GitHub Actions を選択し、以下を登録:
   - Organization / User: `finelagusaz`
   - Repository: `jp-labor-evidence-mcp`
   - Workflow filename: `release.yml`
3. （provenance のため）リポジトリが public であること

## 運用上の含意（CHANGELOG）

自動 publish 化に伴い、従来の「`YYYY-MM-DD` placeholder を publish 時に手で置換」運用は成立しなくなる。**version bump PR の時点で実日付を記入**する運用へ移行が必要（merge = release のため）。CLAUDE.md の Release workflow 追記は別途。

## 検証

- `actionlint` clean（構文 / shellcheck / injection チェック通過）
- untrusted input（commit message・PR body 等）を `run:` に展開していないことを確認
- 本 PR 自体が `ci.yml`（`pull_request`）を走らせる自己検証になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)