### PR TITLE
chore(release): 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 このプロジェクトの主な変更を記録します。
 
+## [0.4.2] - 2026-06-10
+
+### Security
+
+- `@modelcontextprotocol/sdk` の HTTP transport 系 transitive dependency に由来する `npm audit` 7 件（high 5 / moderate 2）を `package.json` の `overrides` で patched 版へ pin して解消
+  - `hono` `^4.12.25` / `path-to-regexp` `^8.4.2` / `qs` `^6.15.2` / `ip-address` `^10.2.0` / `fast-uri` `^3.1.2` / `@hono/node-server` `^1.19.13` / `express-rate-limit` `^8.2.2`
+  - 本サーバーは stdio transport 専用で `express` / `hono` の HTTP 経路は実行時に呼ばれないため実害は休眠だが、audit ノイズを除去。全 override は同一 major 内の patched 版で親パッケージの範囲制約と両立
+  - `overrides` は SDK が将来これらの dep を patched 版へ bump したら撤去すべき暫定措置
+
+### Changed
+
+- （CI）GitHub Actions を導入: `ci.yml`（PR / push で Node 20/22/24 マトリクスの test + build + pack）と、OIDC Trusted Publishing による `release.yml`（version bump が main に乗ると自動 publish + tag + GitHub release）
+- （テスト）freshness 依存テスト（`tool-wire-contract` / `find-related-sources`）の実時刻結合を fake-timer 固定化し、`GENERATED_AT` から 60 日経過で再赤化する time-bomb を解消
+
 ## [0.4.1] - 2026-06-10
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jp-labor-evidence-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jp-labor-evidence-mcp",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp-labor-evidence-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "MCP server for Japanese labor and social insurance primary-source evidence",
   "type": "module",
   "main": "dist/index.js",

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ export function createServer(): McpServer {
   const server = new McpServer(
     {
       name: 'jp-labor-evidence-mcp',
-      version: '0.4.1',
+      version: '0.4.2',
     },
     {
       instructions: `日本の労働・社会保険法令と行政通達の一次情報を取得するMCPサーバーです。


### PR DESCRIPTION
## 概要

`0.4.2` リリース。0.4.1 以降に main へ入った変更（脆弱性 overrides #13 / CI 導入 #17 / freshness テスト堅牢化 #14）を出荷する。

## 変更

- `version` 0.4.1 → 0.4.2（`package.json` + `src/server.ts` + `package-lock.json`）
- `CHANGELOG.md` に `## [0.4.2] - 2026-06-10` を追記（**実日付**。自動 publish 化に伴い placeholder 運用は廃止）

## 含まれる変更（0.4.1 → 0.4.2）

- **Security**: `@modelcontextprotocol/sdk` 由来の transitive 脆弱性 7 件を `overrides` で patched 版へ pin（#13）
- **CI**: GitHub Actions（CI ゲート + OIDC Trusted Publishing）導入（#17）
- **Test**: freshness テストの fake-timer 固定化で time-bomb 解消（#14）

## ⚠️ マージ時の挙動

このPRを main にマージすると **`release.yml` が発火し、OIDC Trusted Publishing で 0.4.2 を自動 publish** する（+ `v0.4.2` タグ + GitHub release 生成）。

**前提**: npmjs.com で本パッケージの **Trusted Publisher（repo=`finelagusaz/jp-labor-evidence-mcp` / workflow=`release.yml`）が設定済み**であること。未設定の場合は publish ステップが失敗するが、idempotent なので設定後に `release.yml` を `workflow_dispatch` で再実行すればよい。

## 検証

- `npm run release:check`: 115 passed / build / pack（`jp-labor-evidence-mcp-0.4.2.tgz`）
- `npm audit`: 0 件
- 本 PR は main の `ci.yml`（Node 20/22/24）でも検証される

🤖 Generated with [Claude Code](https://claude.com/claude-code)