### PR TITLE
ci: bump actions/checkout and setup-node to v6 (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## 概要

`0.4.2` の release 実行時に出た **Node 20 runtime 非推奨 warning** への対応。`actions/checkout@v4` と `actions/setup-node@v4` は Node 20 runtime で動作し、GitHub は **2026-06-16 に Node 24 へ強制移行**する。最新メジャー **v6** へ追従する。

## 変更

`ci.yml` / `release.yml` の両方:
- `actions/checkout@v4` → `@v6`（v6.0.3、Node 24 runtime）
- `actions/setup-node@v4` → `@v6`（v6.4.0、Node 24 runtime）

## 検証

- `actionlint` clean
- 本 PR 自体が `ci.yml`（@v6）を `pull_request` で走らせ、新 action 版の動作を自己検証する
- workflow ファイルのみの変更ゆえ、マージしても `release.yml`（`paths: package.json`）は発火しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)