### PR TITLE
docs: fix CLAUDE.md tool count and clarify sync:indexes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,14 @@ MCP server providing primary-source Japanese labor law evidence (法令、行政
 - `npm test` / `npm run test:watch` — vitest
 - `npm run build` — tsc → `dist/`
 - `npm run release:check` — test + build + pack:dry-run、npm publish 前の必須 gate
-- `npm run sync:indexes[:full|:incremental]` — 内部 index の更新 script
+- `npm run sync:indexes[:full|:incremental]` — 内部 index の更新 script（**ネットワーク取得なし**。registry の bundled/seed を gitignored runtime store へ再シリアライズするだけ）
 - CI: `.github/workflows/ci.yml`（PR/push で Node 20/22/24 の test+build+pack）+ `release.yml`（自動 publish。下記 Release workflow 参照）
 
 ## Architecture
 
 - `src/index.ts` — bootstrap (stdio transport + observability reporter + emitStartupWarnings)
 - `src/server.ts` — `McpServer` factory、`instructions` field に LLM 向けガイダンス
-- `src/tools/*.ts` — 11 個の MCP tool。各 handler は envelope 構築時に warnings を merge
+- `src/tools/*.ts` — 12 個の MCP tool（うち `get_law` は deprecated）。各 handler は envelope 構築時に warnings を merge
 - `src/lib/indexes/` — egov / mhlw / jaish 内部索引（bundled vs runtime）
 - `src/lib/indexes/freshness-warnings.ts` — `getIndexWarningsForTool(sources)` ヘルパ
 - `src/lib/services/` — upstream API 呼び出しと normalize


### PR DESCRIPTION
## 概要

`claude-md-improver` の監査で判明した CLAUDE.md の currency 不一致を修正。

## 変更

- **ツール数**: 「11 個の MCP tool」→「12 個（うち `get_law` は deprecated）」。`src/server.ts` の `register*Tool` 呼び出しは 12 件、`src/tools/*.ts` も 12 ファイルで実コードと不一致だった
- **sync:indexes の挙動明記**: index 層に http 取得は無く、`sync:indexes` は upstream を fetch せず registry の bundled/seed を gitignored runtime store へ再シリアライズするだけ、という非自明な点を追記（「sync すれば最新法令が入る」誤解の防止）

ドキュメントのみの変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)