### PR TITLE
refactor(warnings): extract toWireWarnings() helper (#6)

### DIFF
--- a/src/lib/indexes/freshness-warnings.ts
+++ b/src/lib/indexes/freshness-warnings.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getEgovIndexMeta } from './egov-index.js';
 import { indexMetadataRegistry, inferFreshness } from './index-metadata.js';
 import type { IndexSource } from './types.js';
+import type { WarningMessage } from '../types.js';
 
 export const BUNDLED_AGE_THRESHOLD_DAYS = 60;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -91,6 +92,15 @@ export function getIndexWarningsForTool(
     }
   }
   return warnings;
+}
+
+/**
+ * Strips the internal `source` field so a `FreshnessWarning` matches the
+ * `WarningMessage` ({code, message}) shape carried on tool envelopes. Centralised
+ * so a future `WarningMessage` shape change touches one place, not every handler.
+ */
+export function toWireWarnings(warnings: FreshnessWarning[]): WarningMessage[] {
+  return warnings.map(({ code, message }) => ({ code, message }));
 }
 
 export async function emitStartupWarnings(

--- a/src/tools/diff-revision.ts
+++ b/src/tools/diff-revision.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import { createToolEnvelopeSchema, createToolResult, mapErrorToEnvelope } from '../lib/tool-contract.js';
 import { diffRevision } from '../lib/services/diff-revision-service.js';
 
@@ -70,7 +70,7 @@ export function registerDiffRevisionTool(server: McpServer) {
           item: args.item,
         });
 
-        const freshnessWarnings = getIndexWarningsForTool(['egov']).map(({ code, message }) => ({ code, message }));
+        const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['egov']));
         const envelope = {
           status: result.status,
           retryable: false,

--- a/src/tools/find-related-sources.ts
+++ b/src/tools/find-related-sources.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { buildEgovLawCanonicalId } from '../lib/canonical-id.js';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import { findRelatedSources } from '../lib/services/law-service.js';
 import { createToolEnvelopeSchema, createToolResult, isoNow, mapErrorToEnvelope } from '../lib/tool-contract.js';
 
@@ -45,7 +45,7 @@ export function registerFindRelatedSourcesTool(server: McpServer) {
     async (args) => {
       const startedAt = Date.now();
       try {
-        const freshnessWarnings = getIndexWarningsForTool(['egov', 'mhlw', 'jaish']).map(({ code, message }) => ({ code, message }));
+        const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['egov', 'mhlw', 'jaish']));
         const result = await findRelatedSources({
           lawId: args.law_id,
           article: args.article,

--- a/src/tools/get-article.ts
+++ b/src/tools/get-article.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { buildEgovArticleCanonicalId } from '../lib/canonical-id.js';
 import { computeUpstreamHash, joinVersionInfo } from '../lib/evidence-metadata.js';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import { getArticleByLawId } from '../lib/services/law-service.js';
 import { createToolEnvelopeSchema, createToolResult, isoNow, mapErrorToEnvelope } from '../lib/tool-contract.js';
 
@@ -64,7 +64,7 @@ export function registerGetArticleTool(server: McpServer) {
         const title = `${result.lawTitle} ${articleDisplay}${paraDisplay}${itemDisplay}`;
         const body = `${result.articleCaption ? `（${result.articleCaption}）\n` : ''}${result.text}`;
         const versionInfo = joinVersionInfo([result.lawNum, result.promulgationDate]);
-        const freshnessWarnings = getIndexWarningsForTool(['egov']).map(({ code, message }) => ({ code, message }));
+        const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['egov']));
 
         const envelope = {
           status: 'ok' as const,

--- a/src/tools/get-evidence-bundle.ts
+++ b/src/tools/get-evidence-bundle.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import { getEvidenceBundle } from '../lib/services/evidence-bundle-service.js';
 import { createToolEnvelopeSchema, createToolResult, mapErrorToEnvelope } from '../lib/tool-contract.js';
 
@@ -84,7 +84,7 @@ export function registerGetEvidenceBundleTool(server: McpServer) {
     async (args) => {
       const startedAt = Date.now();
       try {
-        const freshnessWarnings = getIndexWarningsForTool(['egov', 'mhlw', 'jaish']).map(({ code, message }) => ({ code, message }));
+        const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['egov', 'mhlw', 'jaish']));
         const result = await getEvidenceBundle({
           lawId: args.law_id,
           article: args.article,

--- a/src/tools/get-jaish-tsutatsu.ts
+++ b/src/tools/get-jaish-tsutatsu.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { buildJaishCanonicalId } from '../lib/canonical-id.js';
 import { computeUpstreamHash, joinVersionInfo } from '../lib/evidence-metadata.js';
 import { getJaishTsutatsu } from '../lib/services/jaish-tsutatsu-service.js';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import { createToolEnvelopeSchema, createToolResult, isoNow, mapErrorToEnvelope } from '../lib/tool-contract.js';
 
 const getJaishInputSchema = z.object({
@@ -36,7 +36,7 @@ export function registerGetJaishTsutatsuTool(server: McpServer) {
     },
     async (args) => {
       const startedAt = Date.now();
-      const freshnessWarnings = getIndexWarningsForTool(['jaish']).map(({ code, message }) => ({ code, message }));
+      const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['jaish']));
       try {
         const result = await getJaishTsutatsu({ url: args.url });
 

--- a/src/tools/get-law.ts
+++ b/src/tools/get-law.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { buildEgovArticleCanonicalId, buildEgovTocCanonicalId } from '../lib/canonical-id.js';
 import { computeUpstreamHash, joinVersionInfo } from '../lib/evidence-metadata.js';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import { getLawArticle, getLawToc } from '../lib/services/law-service.js';
 import { createToolEnvelopeSchema, createToolResult, isoNow, mapErrorToEnvelope } from '../lib/tool-contract.js';
 
@@ -58,7 +58,7 @@ export function registerGetLawTool(server: McpServer) {
           code: 'DEPRECATED_TOOL',
           message: 'get_law は非推奨です。新規利用では resolve_law と get_article を使用してください。',
         };
-        const freshnessWarnings = getIndexWarningsForTool(['egov']).map(({ code, message }) => ({ code, message }));
+        const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['egov']));
         if (args.format === 'toc') {
           const result = await getLawToc({ lawName: args.law_name });
           const lawId = result.egovUrl.split('/').pop() ?? args.law_name;

--- a/src/tools/get-mhlw-tsutatsu.ts
+++ b/src/tools/get-mhlw-tsutatsu.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { buildMhlwCanonicalId } from '../lib/canonical-id.js';
 import { computeUpstreamHash, joinVersionInfo } from '../lib/evidence-metadata.js';
 import { getMhlwTsutatsu } from '../lib/services/mhlw-tsutatsu-service.js';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import { createToolEnvelopeSchema, createToolResult, isoNow, mapErrorToEnvelope } from '../lib/tool-contract.js';
 
 const getMhlwInputSchema = z.object({
@@ -40,7 +40,7 @@ export function registerGetMhlwTsutatsuTool(server: McpServer) {
     },
     async (args) => {
       const startedAt = Date.now();
-      const freshnessWarnings = getIndexWarningsForTool(['mhlw']).map(({ code, message }) => ({ code, message }));
+      const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['mhlw']));
       try {
         const result = await getMhlwTsutatsu({
           dataId: args.data_id,

--- a/src/tools/resolve-law.ts
+++ b/src/tools/resolve-law.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { buildEgovLawCanonicalId } from '../lib/canonical-id.js';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import { resolveLaw } from '../lib/services/law-service.js';
 import { createToolEnvelopeSchema, createToolResult, isoNow, mapErrorToEnvelope } from '../lib/tool-contract.js';
 
@@ -42,7 +42,7 @@ export function registerResolveLawTool(server: McpServer) {
       const startedAt = Date.now();
       try {
         const result = await resolveLaw({ query: args.query });
-        const freshnessWarnings = getIndexWarningsForTool(['egov']).map(({ code, message }) => ({ code, message }));
+        const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['egov']));
         const envelope = {
           status:
             result.resolution === 'resolved' ? 'ok' as const :

--- a/src/tools/search-jaish-tsutatsu.ts
+++ b/src/tools/search-jaish-tsutatsu.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { buildJaishCanonicalId } from '../lib/canonical-id.js';
 import type { CitationBasis } from '../lib/indexes/types.js';
 import { searchJaishTsutatsu } from '../lib/services/jaish-tsutatsu-service.js';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import { createToolEnvelopeSchema, createToolResult, isoNow, mapErrorToEnvelope } from '../lib/tool-contract.js';
 
 const searchJaishInputSchema = z.object({
@@ -61,7 +61,7 @@ export function registerSearchJaishTsutatsuTool(server: McpServer) {
     },
     async (args) => {
       const startedAt = Date.now();
-      const freshnessWarnings = getIndexWarningsForTool(['jaish']).map(({ code, message }) => ({ code, message }));
+      const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['jaish']));
       try {
         const result = await searchJaishTsutatsu({
           keyword: args.keyword,

--- a/src/tools/search-law.ts
+++ b/src/tools/search-law.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { buildEgovLawCanonicalId } from '../lib/canonical-id.js';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import type { CitationBasis } from '../lib/indexes/types.js';
 import { searchLaw } from '../lib/services/law-service.js';
 import { createToolEnvelopeSchema, createToolResult, isoNow, mapErrorToEnvelope } from '../lib/tool-contract.js';
@@ -70,7 +70,7 @@ export function registerSearchLawTool(server: McpServer) {
         const sourceUrl = 'https://laws.e-gov.go.jp/';
         const candidateBasis: CitationBasis = result.usedIndex ? 'index' : 'upstream';
         const indexLine = `検索経路: ${result.route}${result.indexMeta ? ` / freshness=${result.indexMeta.freshness}` : ''}`;
-        const freshnessWarnings = getIndexWarningsForTool(['egov']).map(({ code, message }) => ({ code, message }));
+        const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['egov']));
         const envelope = {
           status: result.results.length === 0 ? 'not_found' as const : 'ok' as const,
           retryable: false,

--- a/src/tools/search-mhlw-tsutatsu.ts
+++ b/src/tools/search-mhlw-tsutatsu.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { buildMhlwDocumentCanonicalId } from '../lib/canonical-id.js';
 import type { CitationBasis } from '../lib/indexes/types.js';
 import { searchMhlwTsutatsu } from '../lib/services/mhlw-tsutatsu-service.js';
-import { getIndexWarningsForTool } from '../lib/indexes/freshness-warnings.js';
+import { getIndexWarningsForTool, toWireWarnings } from '../lib/indexes/freshness-warnings.js';
 import { createToolEnvelopeSchema, createToolResult, isoNow, mapErrorToEnvelope } from '../lib/tool-contract.js';
 
 const searchMhlwInputSchema = z.object({
@@ -58,7 +58,7 @@ export function registerSearchMhlwTsutatsuTool(server: McpServer) {
     },
     async (args) => {
       const startedAt = Date.now();
-      const freshnessWarnings = getIndexWarningsForTool(['mhlw']).map(({ code, message }) => ({ code, message }));
+      const freshnessWarnings = toWireWarnings(getIndexWarningsForTool(['mhlw']));
       try {
         const result = await searchMhlwTsutatsu({
           keyword: args.keyword,

--- a/tests/freshness-warnings.test.ts
+++ b/tests/freshness-warnings.test.ts
@@ -273,4 +273,24 @@ describe('freshness-warnings', () => {
       stderrSpy.mockRestore();
     });
   });
+
+  describe('toWireWarnings', () => {
+    it('FreshnessWarning[] から source を落として {code, message} に揃える', async () => {
+      const { toWireWarnings } = await import('../src/lib/indexes/freshness-warnings.js');
+      const wire = toWireWarnings([
+        { code: 'BUNDLED_INDEX_AGED', source: 'egov', message: 'm1' },
+        { code: 'RUNTIME_INDEX_STALE', source: 'mhlw', message: 'm2' },
+      ]);
+      expect(wire).toEqual([
+        { code: 'BUNDLED_INDEX_AGED', message: 'm1' },
+        { code: 'RUNTIME_INDEX_STALE', message: 'm2' },
+      ]);
+      expect(wire[0]).not.toHaveProperty('source');
+    });
+
+    it('空配列はそのまま空配列', async () => {
+      const { toWireWarnings } = await import('../src/lib/indexes/freshness-warnings.js');
+      expect(toWireWarnings([])).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## 概要

Issue #6 対応。freshness warnings 実装で 11 個の tool handler に重複していた wire-shape 変換を `toWireWarnings()` ヘルパへ集約する **pure refactor**。

```ts
// before（11 箇所）
getIndexWarningsForTool(['egov']).map(({ code, message }) => ({ code, message }))
// after
toWireWarnings(getIndexWarningsForTool(['egov']))
```

`FreshnessWarning` の内部 `source` フィールドを strip して envelope の `WarningMessage` ({code, message}) 形へ揃える責務を 1 箇所に寄せ、将来 wire shape が変わっても drift しないようにする。

## 変更

- `src/lib/indexes/freshness-warnings.ts`: `toWireWarnings(FreshnessWarning[]): WarningMessage[]` を追加
- 11 tool handler: `.map(strip)` → `toWireWarnings(...)`、import に追加
- `tests/freshness-warnings.test.ts`: `toWireWarnings` の unit test 2 件（source strip / 空配列）

## 検証

- 振る舞い不変（envelope の warnings 形は同一）
- 全 117 test green / `tsc` build clean

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)