### PR TITLE
refactor(indexes): consolidate DAY_MS & bundled_age_days compute (#5)

### DIFF
--- a/src/lib/indexes/egov-index.ts
+++ b/src/lib/indexes/egov-index.ts
@@ -5,9 +5,9 @@ import { loadLastKnownGoodLawIndexSnapshot, loadLawIndexSnapshot, restoreCurrent
 import { promoteLawIndexSnapshot } from './promotion.js';
 import type { SerializedLawIndex } from './serialization.js';
 import type { IndexSnapshotMeta, LawIndexEntry } from './types.js';
+import { computeBundledAgeDays } from './time.js';
 
 const GENERATED_AT = '2026-06-10T00:00:00.000Z';
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 function inferLawType(lawTitle: string): string {
   if (lawTitle.endsWith('施行令')) {
@@ -60,12 +60,9 @@ const DEFAULT_EGOV_INDEX_META: IndexSnapshotMeta = {
 
 function withBundledAge(meta: IndexSnapshotMeta): IndexSnapshotMeta {
   if (meta.source !== 'egov') return meta;
-  const generatedMs = Date.parse(meta.generated_at);
-  if (Number.isNaN(generatedMs)) return meta;
-  return {
-    ...meta,
-    bundled_age_days: Math.floor((Date.now() - generatedMs) / DAY_MS),
-  };
+  const bundledAgeDays = computeBundledAgeDays(meta.generated_at);
+  if (bundledAgeDays === undefined) return meta;
+  return { ...meta, bundled_age_days: bundledAgeDays };
 }
 
 let lawIndexEntries: LawIndexEntry[] = DEFAULT_LAW_INDEX_ENTRIES;

--- a/src/lib/indexes/freshness-warnings.ts
+++ b/src/lib/indexes/freshness-warnings.ts
@@ -3,9 +3,9 @@ import { getEgovIndexMeta } from './egov-index.js';
 import { indexMetadataRegistry, inferFreshness } from './index-metadata.js';
 import type { IndexSource } from './types.js';
 import type { WarningMessage } from '../types.js';
+import { DAY_MS } from './time.js';
 
 export const BUNDLED_AGE_THRESHOLD_DAYS = 60;
-const DAY_MS = 24 * 60 * 60 * 1000;
 const BUNDLED_AGE_THRESHOLD_MS = BUNDLED_AGE_THRESHOLD_DAYS * DAY_MS;
 const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 

--- a/src/lib/indexes/index-metadata.ts
+++ b/src/lib/indexes/index-metadata.ts
@@ -1,8 +1,8 @@
 import { getIndexFilePath, hasPersistedIndex } from './index-store.js';
 import type { IndexFreshness, IndexSnapshotMeta, IndexSource } from './types.js';
+import { DAY_MS, computeBundledAgeDays } from './time.js';
 
-const STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
-const DAY_MS = 24 * 60 * 60 * 1000;
+const STALE_AFTER_MS = 7 * DAY_MS;
 
 type MutableIndexSnapshotMeta = {
   source: IndexSource;
@@ -88,12 +88,7 @@ class IndexMetadataRegistry {
       .map((snapshot) => {
         const bundledAgeDays =
           snapshot.source === 'egov'
-            ? (() => {
-                const generatedMs = Date.parse(snapshot.generated_at);
-                return Number.isNaN(generatedMs)
-                  ? undefined
-                  : Math.floor((Date.now() - generatedMs) / DAY_MS);
-              })()
+            ? computeBundledAgeDays(snapshot.generated_at)
             : undefined;
         return {
           source: snapshot.source,

--- a/src/lib/indexes/time.ts
+++ b/src/lib/indexes/time.ts
@@ -1,0 +1,18 @@
+/** One day in milliseconds. Single source of truth for index time math. */
+export const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Whole-day age of a bundled index from its `generated_at` ISO timestamp to
+ * `now`. Returns `undefined` when `generatedAt` is unparseable.
+ *
+ * Single source of truth for the `bundled_age_days` formula, shared by
+ * `egov-index.ts::withBundledAge` and `index-metadata.ts::list`.
+ */
+export function computeBundledAgeDays(
+  generatedAt: string,
+  now: number = Date.now(),
+): number | undefined {
+  const generatedMs = Date.parse(generatedAt);
+  if (Number.isNaN(generatedMs)) return undefined;
+  return Math.floor((now - generatedMs) / DAY_MS);
+}

--- a/tests/indexes-time.test.ts
+++ b/tests/indexes-time.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { DAY_MS, computeBundledAgeDays } from '../src/lib/indexes/time.js';
+
+describe('indexes/time', () => {
+  it('DAY_MS は 24 時間のミリ秒', () => {
+    expect(DAY_MS).toBe(86_400_000);
+  });
+
+  describe('computeBundledAgeDays', () => {
+    const base = Date.parse('2026-06-10T00:00:00.000Z');
+
+    it('生成時刻からの経過日数を floor で返す', () => {
+      expect(computeBundledAgeDays('2026-06-10T00:00:00.000Z', base + 5 * DAY_MS)).toBe(5);
+    });
+
+    it('端数日は切り捨てる', () => {
+      expect(computeBundledAgeDays('2026-06-10T00:00:00.000Z', base + 5 * DAY_MS + DAY_MS / 2)).toBe(5);
+    });
+
+    it('同時刻なら 0', () => {
+      expect(computeBundledAgeDays('2026-06-10T00:00:00.000Z', base)).toBe(0);
+    });
+
+    it('パース不能な生成時刻は undefined', () => {
+      expect(computeBundledAgeDays('not-a-date', base)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## 概要

Issue #5 対応。freshness warnings 実装後に flagged された軽微な tech debt の解消（**pure refactor**）。

1. `DAY_MS = 24*60*60*1000` が 3 ファイルで重複定義
2. `bundled_age_days` の計算式が 2 経路に散在（`egov-index::withBundledAge` / `index-metadata::list`）

片方を変えると不整合になりうる、というのが本 issue の risk。

## 変更

- 新規 leaf module `src/lib/indexes/time.ts`:
  - `DAY_MS`
  - `computeBundledAgeDays(generatedAt, now = Date.now()): number | undefined`
  - egov-index ↔ index-metadata の循環 import を避けるため、双方が安全に import できる leaf に配置
- `egov-index.ts` / `index-metadata.ts` / `freshness-warnings.ts` の local `DAY_MS` を import へ
- `index-metadata.ts` の `STALE_AFTER_MS` も `7 * DAY_MS` に
- `withBundledAge` / `list()` は `computeBundledAgeDays` を呼ぶだけにし、式を 1 本化
- `tests/indexes-time.test.ts`: 新ヘルパの unit test 5 件

## 検証

- 振る舞い不変（NaN 時に key を付けない／undefined にする既存挙動も保持）
- 全 122 test green / `tsc` build clean

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)