### PR TITLE
feat(warnings): suppress freshness warnings via env var (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ npm run sync:indexes:incremental
 - 通達検索は internal index 優先だが、coverage や freshness によって route は変わる
 - `coverage_below_threshold` のときは fallback を抑止することがある
 - `stale_but_usable` は stale index を使っているので、上位クライアント側で注意表示した方がよい
+- 内蔵法令／通達インデックスが古い場合、tool response の `warnings[]` と起動時ログに freshness 警告が出る。意図的に古い bundle を使う場合（過去事案の再現調査、バージョン固定の回帰環境、オフライン長期運用など）は `LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS=1` で抑止できる
 - `diff_revision` は真の改正履歴 API ではなく、同一法令の 2 つの `law_id` 比較である
 - 判例・裁判例は対象外
 

--- a/src/lib/indexes/freshness-warnings.ts
+++ b/src/lib/indexes/freshness-warnings.ts
@@ -79,10 +79,35 @@ export function getRuntimeIndexWarnings(
   return [{ code: 'RUNTIME_INDEX_STALE', source, message }];
 }
 
+const SUPPRESS_FRESHNESS_ENV = 'LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS';
+const FALSY_ENV_VALUES = new Set(['', '0', 'false', 'no', 'off']);
+
+/**
+ * Whether freshness warnings are suppressed via the
+ * `LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS` env var. Enabled for any value
+ * other than '' / '0' / 'false' / 'no' / 'off' (case-insensitive).
+ *
+ * Intended for intentionally-frozen bundles — historical-case reproduction,
+ * pinned regression environments, deliberate offline operation — where
+ * staleness warnings are noise. When enabled, both the startup notification
+ * (`emitStartupWarnings`) and the per-tool-response merge
+ * (`getIndexWarningsForTool`) are skipped. The low-level getters
+ * (`getBundledIndexWarnings` / `getRuntimeIndexWarnings`) stay pure so a status
+ * resource can still surface the true state.
+ */
+export function isFreshnessWarningsSuppressed(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  const raw = env[SUPPRESS_FRESHNESS_ENV];
+  if (raw === undefined) return false;
+  return !FALSY_ENV_VALUES.has(raw.trim().toLowerCase());
+}
+
 export function getIndexWarningsForTool(
   sources: ReadonlyArray<IndexSource>,
   now: number = Date.now()
 ): FreshnessWarning[] {
+  if (isFreshnessWarningsSuppressed()) return [];
   const warnings: FreshnessWarning[] = [];
   for (const source of sources) {
     if (source === 'egov') {
@@ -107,6 +132,7 @@ export async function emitStartupWarnings(
   server: McpServer,
   now: number = Date.now()
 ): Promise<void> {
+  if (isFreshnessWarningsSuppressed()) return;
   const warnings = getBundledIndexWarnings(now);
   if (warnings.length === 0) return;
   for (const warning of warnings) {

--- a/tests/freshness-warnings.test.ts
+++ b/tests/freshness-warnings.test.ts
@@ -293,4 +293,50 @@ describe('freshness-warnings', () => {
       expect(toWireWarnings([])).toEqual([]);
     });
   });
+
+  describe('freshness 抑止 (LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS)', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('未設定なら抑止しない', async () => {
+      const { isFreshnessWarningsSuppressed } = await import('../src/lib/indexes/freshness-warnings.js');
+      expect(isFreshnessWarningsSuppressed({})).toBe(false);
+    });
+
+    it('1 / true / yes / on は抑止（大文字小文字無視）', async () => {
+      const { isFreshnessWarningsSuppressed } = await import('../src/lib/indexes/freshness-warnings.js');
+      for (const v of ['1', 'true', 'TRUE', 'yes', 'on']) {
+        expect(isFreshnessWarningsSuppressed({ LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS: v })).toBe(true);
+      }
+    });
+
+    it('0 / false / no / off / 空文字は抑止しない', async () => {
+      const { isFreshnessWarningsSuppressed } = await import('../src/lib/indexes/freshness-warnings.js');
+      for (const v of ['0', 'false', 'no', 'off', '', '  ']) {
+        expect(isFreshnessWarningsSuppressed({ LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS: v })).toBe(false);
+      }
+    });
+
+    it('抑止時は getIndexWarningsForTool が aged でも空配列を返す', async () => {
+      vi.stubEnv('LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS', '1');
+      const { getIndexWarningsForTool } = await import('../src/lib/indexes/freshness-warnings.js');
+      const agedNow = GENERATED_AT_MS + 61 * DAY;
+      expect(getIndexWarningsForTool(['egov'], agedNow)).toEqual([]);
+    });
+
+    it('抑止時は emitStartupWarnings が aged でも何もしない', async () => {
+      vi.stubEnv('LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS', '1');
+      const { emitStartupWarnings } = await import('../src/lib/indexes/freshness-warnings.js');
+      const sendLoggingMessage = vi.fn();
+      const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const agedNow = GENERATED_AT_MS + 61 * DAY;
+
+      await emitStartupWarnings({ sendLoggingMessage } as any, agedNow);
+
+      expect(sendLoggingMessage).not.toHaveBeenCalled();
+      expect(stderrSpy).not.toHaveBeenCalled();
+      stderrSpy.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
## 概要

Issue #1 対応。意図的に古い bundle を使うユースケース（過去事案の再現調査 / バージョン固定の回帰環境 / オフライン長期運用）で freshness 警告が雑音になるため、環境変数で抑止できるようにする。

```bash
LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS=1 npx -y jp-labor-evidence-mcp
```

Claude Desktop / Claude Code の MCP config 側で `env` として指定する形でも利用可能。

## 変更

- `isFreshnessWarningsSuppressed(env = process.env)` を追加
  - `''` / `0` / `false` / `no` / `off`（大文字小文字無視）以外の値で有効
- 抑止を 2 経路の **entry-point** に適用:
  - `getIndexWarningsForTool`（tool response への merge）
  - `emitStartupWarnings`（起動時通知）
- 低レベル getter（`getBundledIndexWarnings` / `getRuntimeIndexWarnings`）は**純粋なまま維持**し、後続 #3（status resource）が抑止と無関係に真の状態を出せるようにする
- README「制約と注意」に利用方法を追記
- `tests/freshness-warnings.test.ts`: 判定ロジック + 2 経路の抑止挙動の test 5 件

## 検証

- 全 127 test green / `tsc` build clean

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)