### PR TITLE
feat(warnings): display freshness warning dates in JST (#2)

### DIFF
--- a/src/lib/indexes/freshness-warnings.ts
+++ b/src/lib/indexes/freshness-warnings.ts
@@ -20,8 +20,14 @@ const SOURCE_LABELS: Record<'mhlw' | 'jaish', string> = {
   jaish: '中央労働災害防止協会（JAISH）判例・資料',
 };
 
-function formatDate(ms: number): string {
-  return new Date(ms).toISOString().slice(0, 10);
+/**
+ * Formats a UTC ms timestamp as a `YYYY-MM-DD JST` calendar date in
+ * Asia/Tokyo. Target users are 日本の社労士 / HR なので JST 表記が自然。
+ * Shifting by the JST offset before reading the UTC date also fixes the
+ * off-by-one on JST-midnight boundary timestamps (e.g. 4/1 / 10/1 施行日).
+ */
+function formatJstDate(ms: number): string {
+  return `${new Date(ms + JST_OFFSET_MS).toISOString().slice(0, 10)} JST`;
 }
 
 /**
@@ -57,9 +63,9 @@ export function getBundledIndexWarnings(now: number = Date.now()): FreshnessWarn
   if (!aged && !crossedBoundary) return [];
   const ageDays = Math.floor(elapsedMs / DAY_MS);
   const boundaryNote = crossedBoundary
-    ? `（直近の労働法令改正施行日 ${formatDate(boundaryMs)} を跨いでいるため、4/1 / 10/1 施行改正が反映されていない可能性があります）`
+    ? `（直近の労働法令改正施行日 ${formatJstDate(boundaryMs)} を跨いでいるため、4/1 / 10/1 施行改正が反映されていない可能性があります）`
     : '';
-  const message = `内蔵法令インデックスの生成から ${ageDays} 日経過しています（生成日: ${formatDate(generatedMs)}）${boundaryNote}。最新の法令改正を反映するには、Claude Desktop / Claude Code を再起動してください（\`npx -y\` 起動の場合は再起動で最新パッケージが自動取得されます）。グローバルインストール利用時は \`npm update -g jp-labor-evidence-mcp\` を実行してください。`;
+  const message = `内蔵法令インデックスの生成から ${ageDays} 日経過しています（生成日: ${formatJstDate(generatedMs)}）${boundaryNote}。最新の法令改正を反映するには、Claude Desktop / Claude Code を再起動してください（\`npx -y\` 起動の場合は再起動で最新パッケージが自動取得されます）。グローバルインストール利用時は \`npm update -g jp-labor-evidence-mcp\` を実行してください。`;
   return [{ code: 'BUNDLED_INDEX_AGED', source: 'egov', message }];
 }
 
@@ -75,7 +81,7 @@ export function getRuntimeIndexWarnings(
   if (Number.isNaN(generatedMs)) return [];
   const ageDays = Math.floor((now - generatedMs) / DAY_MS);
   const label = SOURCE_LABELS[source];
-  const message = `${label}のインデックスが古くなっています（最終同期: ${formatDate(generatedMs)}、${ageDays}日前）。同じキーワードで再検索すると最新の情報が反映されます。`;
+  const message = `${label}のインデックスが古くなっています（最終同期: ${formatJstDate(generatedMs)}、${ageDays}日前）。同じキーワードで再検索すると最新の情報が反映されます。`;
   return [{ code: 'RUNTIME_INDEX_STALE', source, message }];
 }
 

--- a/tests/freshness-warnings.test.ts
+++ b/tests/freshness-warnings.test.ts
@@ -339,4 +339,39 @@ describe('freshness-warnings', () => {
       stderrSpy.mockRestore();
     });
   });
+
+  describe('日付の JST 表示', () => {
+    it('runtime warning は UTC ではなく JST の日付を表示する（日跨ぎ）', async () => {
+      // 2026-06-09T15:30:00Z は UTC では 06-09 だが JST では 06-10 00:30
+      const generatedIso = '2026-06-09T15:30:00.000Z';
+      indexMetadataRegistry.register({
+        source: 'mhlw',
+        generated_at: generatedIso,
+        last_success_at: generatedIso,
+        freshness: 'fresh',
+        entry_count: 5,
+      });
+      const { getRuntimeIndexWarnings } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = Date.parse(generatedIso) + 8 * DAY;
+      const message = getRuntimeIndexWarnings('mhlw', now)[0]?.message ?? '';
+      expect(message).toContain('最終同期: 2026-06-10 JST');
+      expect(message).not.toContain('2026-06-09');
+    });
+
+    it('bundled warning の生成日は JST 表記', async () => {
+      const { getBundledIndexWarnings } = await import('../src/lib/indexes/freshness-warnings.js');
+      const now = GENERATED_AT_MS + 61 * DAY;
+      const message = getBundledIndexWarnings(now)[0]?.message ?? '';
+      expect(message).toContain('生成日: 2026-06-10 JST');
+    });
+
+    it('boundary note の施行日は JST 表記（4/1・10/1 を UTC ズレなく表示）', async () => {
+      const { getBundledIndexWarnings } = await import('../src/lib/indexes/freshness-warnings.js');
+      // now = 2026-10-02 00:00 JST（10/1 JST 境界を跨いだ直後）
+      const now = Date.parse('2026-10-01T15:00:00.000Z');
+      const message = getBundledIndexWarnings(now)[0]?.message ?? '';
+      expect(message).toContain('施行日 2026-10-01 JST');
+      expect(message).not.toContain('2026-09-30');
+    });
+  });
 });


### PR DESCRIPTION
## 概要

Issue #2 対応。freshness 警告の日付は UTC 由来（`new Date().toISOString().slice(0,10)`）で、対象ユーザ（日本の社労士 / HR）にとって最大 1 日ズレた不自然な表示だった。JST へ変換し `YYYY-MM-DD JST` 表記にする。

```diff
- 内蔵法令インデックスの生成から 62 日経過しています（生成日: 2026-02-21）。
+ 内蔵法令インデックスの生成から 62 日経過しています（生成日: 2026-02-22 JST）。
```

## 変更

- `formatDate` → `formatJstDate` に改名。JST offset を足してから UTC 日付を読むことで Asia/Tokyo の暦日を得る（生成日・最終同期・施行日の 3 箇所に適用）

### おまけ: 潜在バグの是正

boundary note の**施行日が 1 日前にズレる** off-by-one を同時に是正した。`getMostRecentLawRevisionBoundaryMs` が返す JST 真夜中（4/1 / 10/1 00:00 JST）の timestamp を UTC のまま `slice(0,10)` すると前日になっていた（例: `2026-09-30` ← 正しくは `2026-10-01`）。JST 変換でこれも解消。

## 検証

- 既存テストは message の日付文字列を assert していないため非破壊
- 追加 test 3 件: JST 日跨ぎ / 生成日表記 / 施行日 off-by-one 是正
- 全 130 test green / `tsc` build clean

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)