### PR TITLE
feat(resource): expose freshness status via MCP resource (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ npm run build
 |-----------|----------------------------------------------------------------------------|
 | `get_law` | 非推奨。旧来の法令取得。新規利用では `resolve_law` と `get_article` を使う |
 
+### リソース
+
+| リソース                              | 用途                                                                                      |
+|---------------------------------------|-------------------------------------------------------------------------------------------|
+| `mcp://jp-labor-evidence-mcp/status` | freshness 状態を on-demand で照会する読み取り専用リソース。各 index の `generated_at`・`freshness`・経過日数、現在有効な警告、package version を JSON で返す |
+
+freshness 警告は通常 tool response の `warnings[]` と起動時ログで reactive に通知されるが、本リソースは proactive に状態を確認できる。`LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS` で警告を抑止していても、`active_warnings` は**真の状態**を返す（`freshness_warnings_suppressed` フラグで抑止中か判別可能）。
+
 ## 使い方の例
 
 ### 法令条文

--- a/src/resources/status.ts
+++ b/src/resources/status.ts
@@ -1,0 +1,119 @@
+/**
+ * MCP リソース: サーバー状態 / freshness
+ *
+ * freshness 警告は logging notification と tool envelope の 2 経路に依存する
+ * reactive な設計。本リソースは「今この server の index 状態を教えて」と
+ * on-demand で照会できる proactive な経路を提供し、discoverability と
+ * テスタビリティを高める。
+ */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getEgovIndexMeta } from '../lib/indexes/egov-index.js';
+import { indexMetadataRegistry } from '../lib/indexes/index-metadata.js';
+import { computeBundledAgeDays } from '../lib/indexes/time.js';
+import {
+  getBundledIndexWarnings,
+  getRuntimeIndexWarnings,
+  isFreshnessWarningsSuppressed,
+  type FreshnessWarning,
+} from '../lib/indexes/freshness-warnings.js';
+
+export const STATUS_RESOURCE_URI = 'mcp://jp-labor-evidence-mcp/status';
+
+type IndexStatus = {
+  generated_at: string;
+  freshness: string;
+  bundled_age_days?: number;
+  warning_code?: string;
+};
+
+export type ServerStatus = {
+  package_version: string;
+  generated_at: string;
+  freshness_warnings_suppressed: boolean;
+  indexes: {
+    egov: IndexStatus;
+    mhlw: IndexStatus | null;
+    jaish: IndexStatus | null;
+  };
+  active_warnings: FreshnessWarning[];
+};
+
+function runtimeIndexStatus(
+  source: 'mhlw' | 'jaish',
+  warningBySource: Map<string, FreshnessWarning>,
+): IndexStatus | null {
+  const meta = indexMetadataRegistry.list().find((m) => m.source === source);
+  if (!meta) return null;
+  const status: IndexStatus = {
+    generated_at: meta.generated_at,
+    freshness: meta.freshness,
+  };
+  const warning = warningBySource.get(source);
+  if (warning) status.warning_code = warning.code;
+  return status;
+}
+
+/**
+ * Builds the status payload as a pure function of `now` (the egov age is
+ * recomputed from the injected `now` rather than read off
+ * `getEgovIndexMeta().bundled_age_days`, which is wall-clock based). The
+ * `active_warnings` list reflects the *true* freshness state even when warnings
+ * are suppressed for tool responses (see `isFreshnessWarningsSuppressed`).
+ */
+export function buildServerStatus(
+  packageVersion: string,
+  now: number = Date.now(),
+): ServerStatus {
+  const activeWarnings: FreshnessWarning[] = [
+    ...getBundledIndexWarnings(now),
+    ...getRuntimeIndexWarnings('mhlw', now),
+    ...getRuntimeIndexWarnings('jaish', now),
+  ];
+  const warningBySource = new Map<string, FreshnessWarning>(
+    activeWarnings.map((w) => [w.source, w]),
+  );
+
+  const egovMeta = getEgovIndexMeta();
+  const egov: IndexStatus = {
+    generated_at: egovMeta.generated_at,
+    freshness: egovMeta.freshness,
+  };
+  const egovAgeDays = computeBundledAgeDays(egovMeta.generated_at, now);
+  if (egovAgeDays !== undefined) egov.bundled_age_days = egovAgeDays;
+  const egovWarning = warningBySource.get('egov');
+  if (egovWarning) egov.warning_code = egovWarning.code;
+
+  return {
+    package_version: packageVersion,
+    generated_at: new Date(now).toISOString(),
+    freshness_warnings_suppressed: isFreshnessWarningsSuppressed(),
+    indexes: {
+      egov,
+      mhlw: runtimeIndexStatus('mhlw', warningBySource),
+      jaish: runtimeIndexStatus('jaish', warningBySource),
+    },
+    active_warnings: activeWarnings,
+  };
+}
+
+export function registerStatusResource(server: McpServer, packageVersion: string): void {
+  server.registerResource(
+    'status',
+    STATUS_RESOURCE_URI,
+    {
+      title: 'サーバー状態 / freshness',
+      description:
+        '内蔵法令インデックス（egov）と通達／判例インデックス（mhlw / jaish）の generated_at・freshness・経過日数、現在有効な freshness 警告、package version を返す読み取り専用リソース。',
+      mimeType: 'application/json',
+    },
+    (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: 'application/json',
+          text: JSON.stringify(buildServerStatus(packageVersion), null, 2),
+        },
+      ],
+    }),
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,12 +12,15 @@ import { registerGetMhlwTsutatsuTool } from './tools/get-mhlw-tsutatsu.js';
 import { registerSearchJaishTsutatsuTool } from './tools/search-jaish-tsutatsu.js';
 import { registerGetJaishTsutatsuTool } from './tools/get-jaish-tsutatsu.js';
 import { registerPrompts } from './prompts/index.js';
+import { registerStatusResource } from './resources/status.js';
+
+const SERVER_VERSION = '0.4.2';
 
 export function createServer(): McpServer {
   const server = new McpServer(
     {
       name: 'jp-labor-evidence-mcp',
-      version: '0.4.2',
+      version: SERVER_VERSION,
     },
     {
       instructions: `日本の労働・社会保険法令と行政通達の一次情報を取得するMCPサーバーです。
@@ -68,6 +71,7 @@ warnings の message は既に利用者向け日本語になっています。pa
 
   // 観測性
   registerGetObservabilitySnapshotTool(server); // get_observability_snapshot: メトリクス確認
+  registerStatusResource(server, SERVER_VERSION); // mcp://jp-labor-evidence-mcp/status: freshness 状態
 
   // プロンプトテンプレート
   registerPrompts(server);

--- a/tests/status-resource.test.ts
+++ b/tests/status-resource.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { indexMetadataRegistry } from '../src/lib/indexes/index-metadata.js';
+
+const GENERATED_AT_ISO = '2026-06-10T00:00:00.000Z';
+const GENERATED_AT_MS = Date.parse(GENERATED_AT_ISO);
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('status resource (mcp://jp-labor-evidence-mcp/status)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(GENERATED_AT_MS));
+    indexMetadataRegistry.reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it('fresh 状態: version・egov メタを返し active_warnings は空', async () => {
+    const { buildServerStatus } = await import('../src/resources/status.js');
+    const status = buildServerStatus('9.9.9', GENERATED_AT_MS);
+    expect(status.package_version).toBe('9.9.9');
+    expect(status.indexes.egov.generated_at).toBe(GENERATED_AT_ISO);
+    expect(status.indexes.egov.bundled_age_days).toBe(0);
+    expect(status.indexes.egov.warning_code).toBeUndefined();
+    expect(status.active_warnings).toEqual([]);
+    expect(status.freshness_warnings_suppressed).toBe(false);
+  });
+
+  it('egov age は注入した now の純関数（wall-clock 非依存）', async () => {
+    const { buildServerStatus } = await import('../src/resources/status.js');
+    // system time は GENERATED_AT のままだが、now=+61d を渡すと age=61
+    const status = buildServerStatus('9.9.9', GENERATED_AT_MS + 61 * DAY);
+    expect(status.indexes.egov.bundled_age_days).toBe(61);
+    expect(status.indexes.egov.warning_code).toBe('BUNDLED_INDEX_AGED');
+    expect(
+      status.active_warnings.some((w) => w.code === 'BUNDLED_INDEX_AGED' && w.source === 'egov'),
+    ).toBe(true);
+  });
+
+  it('runtime stale: mhlw の freshness/warning_code と active_warnings を反映', async () => {
+    indexMetadataRegistry.register({
+      source: 'mhlw',
+      generated_at: GENERATED_AT_ISO,
+      last_success_at: GENERATED_AT_ISO,
+      freshness: 'fresh',
+      entry_count: 5,
+    });
+    const { buildServerStatus } = await import('../src/resources/status.js');
+    const status = buildServerStatus('9.9.9', GENERATED_AT_MS + 8 * DAY);
+    expect(status.indexes.mhlw?.warning_code).toBe('RUNTIME_INDEX_STALE');
+    expect(status.active_warnings.some((w) => w.source === 'mhlw')).toBe(true);
+  });
+
+  it('未登録の runtime index は null', async () => {
+    const { buildServerStatus } = await import('../src/resources/status.js');
+    const status = buildServerStatus('9.9.9', GENERATED_AT_MS);
+    expect(status.indexes.jaish).toBeNull();
+  });
+
+  it('抑止中でも active_warnings は真の状態を出し、フラグは true', async () => {
+    vi.stubEnv('LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS', '1');
+    const { buildServerStatus } = await import('../src/resources/status.js');
+    const status = buildServerStatus('9.9.9', GENERATED_AT_MS + 61 * DAY);
+    expect(status.freshness_warnings_suppressed).toBe(true);
+    // 抑止は tool response 用。status resource は真の状態を surface する
+    expect(status.active_warnings.length).toBeGreaterThan(0);
+  });
+
+  it('createServer はリソース登録を含めエラーなく構築できる', async () => {
+    const { createServer } = await import('../src/server.js');
+    expect(() => createServer()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #3 対応。freshness 警告は logging notification と tool envelope の 2 経路に依存する **reactive** な設計だった。「今この server の index 状態を教えて」と on-demand で照会できる **proactive** な経路として、読み取り専用 MCP リソースを追加する。

## リソース

`mcp://jp-labor-evidence-mcp/status`（`application/json`）

```json
{
  "package_version": "0.4.2",
  "generated_at": "2026-06-10T00:00:00.000Z",
  "freshness_warnings_suppressed": false,
  "indexes": {
    "egov":  { "generated_at": "2026-06-10T00:00:00.000Z", "freshness": "unknown", "bundled_age_days": 0 },
    "mhlw":  { "generated_at": "...", "freshness": "fresh" },
    "jaish": { "generated_at": "...", "freshness": "fresh" }
  },
  "active_warnings": []
}
```

## 変更

- `src/resources/status.ts`:
  - `registerStatusResource(server, version)` で `server.registerResource` 登録
  - `buildServerStatus(version, now?)` を**純関数**として分離（テスタブル）
- egov の `bundled_age_days` は `getEgovIndexMeta()` の wall-clock 値ではなく、注入 `now` から `computeBundledAgeDays` で**再計算**（payload を now の純関数に）
- **抑止中でも `active_warnings` は真の状態を surface**。#1 で低レベル getter を純粋に保った設計意図どおり。`freshness_warnings_suppressed` フラグで抑止中か判別可能
- version を `SERVER_VERSION` 定数化し McpServer config とリソースで共有
- README に「リソース」節を追記

## 検証

- `tests/status-resource.test.ts` 6 件（fresh / aged / runtime stale / 未登録 null / 抑止フラグ / createServer 登録 smoke）
- 全 136 test green / `tsc` build clean

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)