### PR TITLE
test(mcp): consolidate SDK internal access into helper (#7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ MCP server providing primary-source Japanese labor law evidence (法令、行政
 
 - 時刻依存: `vi.useFakeTimers()` + `vi.setSystemTime(new Date(...))` + `afterEach(() => vi.useRealTimers())`
 - module-load-time の挙動を test: `vi.resetModules()` + 動的 `import()`（参考: [tests/egov-index.test.ts](tests/egov-index.test.ts)）
-- Tool integration test: `server.server._requestHandlers.get('tools/call')` で handler 直叩き（MCP SDK 1.29.0 internal、Issue #7 で代替経路追跡中）
+- Tool integration test: SDK private field アクセス（`server.server._requestHandlers.get('tools/call')`、`_instructions`）は [tests/test-helpers/mcp-internals.ts](tests/test-helpers/mcp-internals.ts) に集約済み（#7）。tool 呼び出しは `callTool(server, name, args)`、instructions は `getServerInstructions(server)` を使う。SDK を bump すると [tests/mcp-internals.test.ts](tests/mcp-internals.test.ts) の version-guard が赤化するので、private field を再検証して `MCP_SDK_PINNED_VERSION` を更新する
 - Registry seed test: `indexMetadataRegistry.register({...})` で fake meta を直接投入
 
 ## Gotchas

--- a/tests/mcp-internals.test.ts
+++ b/tests/mcp-internals.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { MCP_SDK_PINNED_VERSION, getInstalledMcpSdkVersion } from './test-helpers/mcp-internals.js';
+
+describe('MCP SDK internal-access guard (#7)', () => {
+  it('インストール済み SDK バージョンが pin と一致する', () => {
+    // 不一致になったら test-helpers/mcp-internals.ts の private field アクセスを
+    // 再検証し、問題なければ MCP_SDK_PINNED_VERSION を更新すること。
+    expect(getInstalledMcpSdkVersion()).toBe(MCP_SDK_PINNED_VERSION);
+  });
+});

--- a/tests/server-instructions.test.ts
+++ b/tests/server-instructions.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { createServer } from '../src/server.js';
+import { getServerInstructions } from './test-helpers/mcp-internals.js';
 
 describe('server instructions', () => {
   it('freshness warnings のガイダンスが instructions に含まれる', () => {
     const server = createServer();
-    const internalServer = server.server as unknown as { _instructions?: string; _options?: { instructions?: string } };
-    const instructions = internalServer._instructions ?? internalServer._options?.instructions;
+    const instructions = getServerInstructions(server);
     expect(instructions).toBeDefined();
     expect(instructions).toContain('freshness warnings');
     expect(instructions).toContain('BUNDLED_INDEX_AGED');

--- a/tests/test-helpers/mcp-internals.ts
+++ b/tests/test-helpers/mcp-internals.ts
@@ -1,0 +1,70 @@
+/**
+ * MCP SDK internal-access shim for integration tests.
+ *
+ * The MCP TypeScript SDK does not (yet) expose public test helpers for
+ * invoking a registered tool or reading a server's `instructions`, so these
+ * tests reach into SDK-private fields. Centralising that access HERE keeps the
+ * SDK-version coupling in one place — see Issue #7.
+ *
+ * Validated against @modelcontextprotocol/sdk 1.29.0. When the installed SDK
+ * version changes, `tests/mcp-internals.test.ts` goes red: re-verify the field
+ * names below (`server.server._requestHandlers`, `_instructions` /
+ * `_options.instructions`) still hold, then bump `MCP_SDK_PINNED_VERSION`.
+ * Prefer migrating to a public API if the SDK grows one (e.g.
+ * `server.callTool(...)` / `server.getInstructions()`).
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+/** SDK version whose internals the shims below were validated against. */
+export const MCP_SDK_PINNED_VERSION = '1.29.0';
+
+/** Reads the actually-installed @modelcontextprotocol/sdk version from disk. */
+export function getInstalledMcpSdkVersion(): string {
+  const pkgUrl = new URL(
+    '../../node_modules/@modelcontextprotocol/sdk/package.json',
+    import.meta.url,
+  );
+  const pkg = JSON.parse(readFileSync(fileURLToPath(pkgUrl), 'utf8')) as { version: string };
+  return pkg.version;
+}
+
+type RequestHandler = (req: unknown) => Promise<{ structuredContent?: unknown }>;
+
+/**
+ * Invokes a registered tool through the SDK's internal `tools/call` request
+ * handler and returns its `structuredContent`.
+ *
+ * SDK-private: `server.server._requestHandlers`.
+ */
+export async function callTool<T = unknown>(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const internal = server.server as unknown as {
+    _requestHandlers: Map<string, RequestHandler>;
+  };
+  const handler = internal._requestHandlers.get('tools/call');
+  if (!handler) throw new Error('tools/call handler not registered');
+  const result = await handler({
+    method: 'tools/call',
+    params: { name, arguments: args },
+  });
+  return result.structuredContent as T;
+}
+
+/**
+ * Reads the server's `instructions` string.
+ *
+ * SDK-private: `_instructions` (newer SDK) with `_options.instructions`
+ * fallback (older SDK).
+ */
+export function getServerInstructions(server: McpServer): string | undefined {
+  const internal = server.server as unknown as {
+    _instructions?: string;
+    _options?: { instructions?: string };
+  };
+  return internal._instructions ?? internal._options?.instructions;
+}

--- a/tests/tool-freshness-warnings.test.ts
+++ b/tests/tool-freshness-warnings.test.ts
@@ -1,22 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { indexMetadataRegistry } from '../src/lib/indexes/index-metadata.js';
+import { callTool } from './test-helpers/mcp-internals.js';
 
 const DAY = 24 * 60 * 60 * 1000;
 const GENERATED_AT_MS = Date.parse('2026-06-10T00:00:00.000Z');
 
-async function callTool(server: McpServer, name: string, args: Record<string, unknown>) {
-  const internal = server.server as unknown as {
-    _requestHandlers: Map<string, (req: any) => Promise<any>>;
-  };
-  const handler = internal._requestHandlers.get('tools/call');
-  if (!handler) throw new Error('tools/call handler not registered');
-  const result = await handler({
-    method: 'tools/call',
-    params: { name, arguments: args },
-  } as any);
-  return result.structuredContent as { warnings: Array<{ code: string; message: string }> };
-}
+type WarningsEnvelope = { warnings: Array<{ code: string; message: string }> };
 
 describe('tool freshness warnings integration', () => {
   beforeEach(() => {
@@ -42,7 +31,7 @@ describe('tool freshness warnings integration', () => {
       });
       const server = createServer();
       vi.useRealTimers();
-      const envelope = await callTool(server, 'search_mhlw_tsutatsu', { keyword: '36協定' });
+      const envelope = await callTool<WarningsEnvelope>(server, 'search_mhlw_tsutatsu', { keyword: '36協定' });
       expect(envelope.warnings.some((w) => w.code === 'RUNTIME_INDEX_STALE' && w.message.includes('厚生労働省通達'))).toBe(true);
     }, 30000);
 
@@ -58,7 +47,7 @@ describe('tool freshness warnings integration', () => {
       });
       const server = createServer();
       vi.useRealTimers();
-      const envelope = await callTool(server, 'search_jaish_tsutatsu', { keyword: '労災' });
+      const envelope = await callTool<WarningsEnvelope>(server, 'search_jaish_tsutatsu', { keyword: '労災' });
       expect(envelope.warnings.some((w) => w.code === 'RUNTIME_INDEX_STALE' && w.message.includes('JAISH'))).toBe(true);
     }, 30000);
   });
@@ -68,7 +57,7 @@ describe('tool freshness warnings integration', () => {
       vi.setSystemTime(new Date(GENERATED_AT_MS + 61 * DAY));
       const { createServer } = await import('../src/server.js');
       const server = createServer();
-      const envelope = await callTool(server, 'resolve_law', { query: '労基法' });
+      const envelope = await callTool<WarningsEnvelope>(server, 'resolve_law', { query: '労基法' });
       expect(envelope.warnings.some((w) => w.code === 'BUNDLED_INDEX_AGED')).toBe(true);
     });
 
@@ -76,7 +65,7 @@ describe('tool freshness warnings integration', () => {
       vi.setSystemTime(new Date(GENERATED_AT_MS + 3 * DAY));
       const { createServer } = await import('../src/server.js');
       const server = createServer();
-      const envelope = await callTool(server, 'resolve_law', { query: '労基法' });
+      const envelope = await callTool<WarningsEnvelope>(server, 'resolve_law', { query: '労基法' });
       expect(envelope.warnings.some((w) => w.code === 'BUNDLED_INDEX_AGED')).toBe(false);
     });
   });
@@ -101,7 +90,7 @@ describe('tool freshness warnings integration', () => {
       vi.setSystemTime(new Date(GENERATED_AT_MS + 61 * DAY));
       const { createServer } = await import('../src/server.js');
       const server = createServer();
-      const envelope = await callTool(server, 'find_related_sources', {
+      const envelope = await callTool<WarningsEnvelope>(server, 'find_related_sources', {
         law_id: '322AC0000000049',
         article: '36',
       });


### PR DESCRIPTION
## 概要

Issue #7 対応。freshness integration tests が MCP SDK の private field（`server.server._requestHandlers`, `_instructions`）に直接アクセスしており、SDK の internal refactor に脆弱だった。SDK バージョン依存を 1 箇所に集約する。

## 変更

- `tests/test-helpers/mcp-internals.ts`（新規）:
  - `callTool(server, name, args)` — `tools/call` handler 直叩きをラップ
  - `getServerInstructions(server)` — `_instructions` / `_options.instructions` フォールバック
  - `MCP_SDK_PINNED_VERSION = '1.29.0'` + `getInstalledMcpSdkVersion()`
- `tests/mcp-internals.test.ts`（新規）: インストール済み SDK バージョンが pin と一致するか検証する **version-guard**。SDK を bump すると赤化し、private field の再検証を促す
  - issue 提案の「CI で SDK upgrade 時に red alert」を、`MCP_SDK_VERSION` env gate ではなく**自己完結な test** で実現
- `tool-freshness-warnings.test.ts` / `server-instructions.test.ts` を helper 経由へ移行（内部アクセスが helper 以外から消えたことを確認済み）
- CLAUDE.md の Testing patterns を集約済みに追従

## 検証

- 全 137 test green / `tsc` build clean
- helper 以外に SDK private field アクセスは残っていない

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)