### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 このプロジェクトの主な変更を記録します。
 
+## [0.5.0] - 2026-06-10
+
+### Added
+
+- freshness 警告の env による抑止 (#1): 環境変数 `LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS` をセットすると、起動時通知 (`emitStartupWarnings`) と tool response への警告 merge (`getIndexWarningsForTool`) を両方 skip。過去事案の再現調査・バージョン固定の回帰環境・オフライン長期運用など、意図的に古い bundle を使う際の雑音を抑制（`''` / `0` / `false` / `no` / `off` 以外の値で有効）
+- freshness 状態の MCP resource 公開 (#3): 読み取り専用リソース `mcp://jp-labor-evidence-mcp/status` を追加。各 index の `generated_at` / `freshness` / `bundled_age_days`、現在有効な `active_warnings`、`package_version`、`freshness_warnings_suppressed` を JSON で返す。reactive な警告経路に対し on-demand の proactive な状態照会を提供。警告抑止中でも `active_warnings` は真の状態を surface する
+
+### Changed
+
+- freshness 警告の日付を JST 表示に (#2): 生成日・最終同期・施行日を UTC 由来から `YYYY-MM-DD JST` 表記へ変更（対象ユーザの 日本の社労士 / HR にとって自然な表記）
+- （内部）11 tool handler に重複していた envelope 警告の wire 変換を `toWireWarnings()` ヘルパへ集約 (#6)
+- （内部）`DAY_MS` の 3 重定義と `bundled_age_days` の 2 経路を `src/lib/indexes/time.ts`（`DAY_MS` / `computeBundledAgeDays`）へ統合 (#5)
+- （テスト）MCP SDK の private field アクセスを `tests/test-helpers/mcp-internals.ts` へ集約し、SDK バージョン不一致で赤化する version-guard を追加 (#7)
+
+### Fixed
+
+- freshness 警告の boundary note で、JST 真夜中（4/1 / 10/1 00:00 JST）の施行日が UTC 由来で 1 日前にズレて表示されていた off-by-one を是正 (#2)
+
 ## [0.4.2] - 2026-06-10
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jp-labor-evidence-mcp",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jp-labor-evidence-mcp",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp-labor-evidence-mcp",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "MCP server for Japanese labor and social insurance primary-source evidence",
   "type": "module",
   "main": "dist/index.js",

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,7 @@ import { registerGetJaishTsutatsuTool } from './tools/get-jaish-tsutatsu.js';
 import { registerPrompts } from './prompts/index.js';
 import { registerStatusResource } from './resources/status.js';
 
-const SERVER_VERSION = '0.4.2';
+const SERVER_VERSION = '0.5.0';
 
 export function createServer(): McpServer {
   const server = new McpServer(


### PR DESCRIPTION
## 概要

0.4.2 以降に main へ蓄積した **freshness UX 機能 3 件＋内部 refactor 3 件** をまとめた **minor リリース**。

| Issue | 種別 | 内容 |
|---|---|---|
| #1 | feat | `LABOR_LAW_MCP_SUPPRESS_FRESHNESS_WARNINGS` で freshness 警告を抑止 |
| #2 | feat/fix | 警告日付を JST 表示（＋施行日 off-by-one 是正） |
| #3 | feat | `mcp://…/status` resource で freshness を proactive 公開 |
| #5 | refactor | `DAY_MS` / `bundled_age_days` を `time.ts` へ統合 |
| #6 | refactor | `toWireWarnings()` で wire 変換を集約 |
| #7 | test | SDK private access を `mcp-internals.ts` へ集約＋version-guard |

## 変更ファイル

- `package.json` / `src/server.ts`（`SERVER_VERSION`）/ `package-lock.json` を **0.5.0** に同期
- `CHANGELOG.md` に `## [0.5.0] - 2026-06-10`（Added / Changed / Fixed）

## リリース手順

- 本 PR を main にマージすると `release.yml` が `package.json` 変更で発火し、OIDC Trusted Publishing で `npm publish --provenance` + `v0.5.0` タグ + GitHub release を自動生成
- `release:check`（test + build + pack:dry-run）はローカルで実行済み（全 137 test green / build clean / tarball 0.5.0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)